### PR TITLE
Added soft break handling to pandoc writer

### DIFF
--- a/remarkup.lua
+++ b/remarkup.lua
@@ -92,6 +92,10 @@ function LineBreak()
   return "\n"
 end
 
+function SoftBreak()
+  return " "
+end
+
 function Emph(s)
   return "//" .. s .. "//"
 end


### PR DESCRIPTION
Implemented undefined function 'SoftBreak'. A soft line break will now be replaced with a space.